### PR TITLE
Add lightweight web UI for feature compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ Artifacts:
   - `And I get_a11y_tree`
   Inspect generated JSON in `proofs/run_*/` to refine selectors or extend regex rules.
 
+## Web UI
+Prefer a visual workflow? Start the lightweight web server and paste your feature text into the browser:
+
+```
+python -m automation_phase1.webui --host 0.0.0.0 --port 8000
+```
+
+Then visit `http://localhost:8000` to compile features and inspect provenance side-by-side. LLM fallback obeys the same environment configuration as the CLI.
+
 ## Design notes
 - Deterministic first; LLM is a last resort behind a flag
 - SQLite cache for compiles (when `--cache` provided)

--- a/automation_phase1/compiler.py
+++ b/automation_phase1/compiler.py
@@ -66,6 +66,22 @@ class Compiler:
                         cache_path: Optional[Path] = None
                         ) -> CompileResult:
         feature_text = feature_path.read_text(encoding="utf-8")
+        overrides = self._load_overrides(overrides_path)
+        return self.compile_text(
+            feature_text=feature_text,
+            scenario_name=scenario_name,
+            base_url=base_url,
+            overrides=overrides,
+            cache_path=cache_path,
+        )
+
+    def compile_text(self,
+                     feature_text: str,
+                     scenario_name: Optional[str] = None,
+                     base_url: Optional[str] = None,
+                     overrides: Optional[dict[str, dict]] = None,
+                     cache_path: Optional[Path] = None
+                     ) -> CompileResult:
         parser = Parser()
         doc = parser.parse(TokenScanner(feature_text))
 
@@ -96,7 +112,7 @@ class Compiler:
         steps_out: list[Step] = []
         provenance: list[CompileProvenance] = []
 
-        overrides = self._load_overrides(overrides_path)
+        overrides = overrides or {}
         if cache_path:
             self._cache_connect(cache_path)
 

--- a/automation_phase1/webui/__init__.py
+++ b/automation_phase1/webui/__init__.py
@@ -1,0 +1,4 @@
+"""Web UI for compiling Gherkin features to automation scenarios."""
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/automation_phase1/webui/__main__.py
+++ b/automation_phase1/webui/__main__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import argparse
+from wsgiref.simple_server import make_server
+
+from .app import create_app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Automation Phase 1 web UI")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind to")
+    parser.add_argument("--port", type=int, default=5000, help="Port to listen on")
+    args = parser.parse_args()
+
+    app = create_app()
+    with make_server(args.host, args.port, app) as server:
+        print(f"Serving on http://{args.host}:{args.port}")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:  # pragma: no cover - manual shutdown
+            print("\nShutting down web UI")
+
+
+if __name__ == "__main__":
+    main()

--- a/automation_phase1/webui/app.py
+++ b/automation_phase1/webui/app.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+from urllib.parse import parse_qs, urlencode
+
+from ..compiler import Compiler
+
+
+@dataclass
+class CompileContext:
+    feature_text: str = ""
+    scenario_name: str = ""
+    base_url: str = ""
+    use_llm: bool = False
+    llm_model: str = "gpt-4o-mini"
+    scenario_json: Optional[str] = None
+    provenance_json: Optional[str] = None
+    error: Optional[str] = None
+
+
+class _Response:
+    def __init__(self, status: str, headers: list[tuple[str, str]], body: bytes):
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    @property
+    def status_code(self) -> int:
+        return int(self.status.split()[0])
+
+    @property
+    def data(self) -> bytes:
+        return self.body
+
+
+class _TestClient:
+    def __init__(self, app: "MiniApp"):
+        self.app = app
+
+    def open(self, path: str, method: str = "GET", data: Optional[dict[str, str]] = None) -> _Response:
+        body_bytes = b""
+        content_type = "text/plain"
+        if method.upper() == "POST" and data is not None:
+            body_bytes = urlencode(data, doseq=True).encode("utf-8")
+            content_type = "application/x-www-form-urlencoded"
+
+        environ = {
+            "REQUEST_METHOD": method.upper(),
+            "PATH_INFO": path,
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "80",
+            "wsgi.version": (1, 0),
+            "wsgi.url_scheme": "http",
+            "wsgi.input": io.BytesIO(body_bytes),
+            "wsgi.errors": io.StringIO(),
+            "wsgi.multithread": False,
+            "wsgi.multiprocess": False,
+            "wsgi.run_once": False,
+            "CONTENT_LENGTH": str(len(body_bytes)),
+            "CONTENT_TYPE": content_type,
+            "QUERY_STRING": "",
+        }
+
+        captured: dict[str, object] = {}
+
+        def start_response(status: str, headers: list[tuple[str, str]]) -> Callable[[bytes], None]:
+            captured["status"] = status
+            captured["headers"] = headers
+
+            def write(_: bytes) -> None:
+                return None
+
+            return write
+
+        body_iter = self.app(environ, start_response)
+        body = b"".join(body_iter)
+        status = captured.get("status", "500 Internal Server Error")  # type: ignore[arg-type]
+        headers = captured.get("headers", [])  # type: ignore[arg-type]
+        return _Response(status=status, headers=headers, body=body)
+
+    def get(self, path: str) -> _Response:
+        return self.open(path, method="GET")
+
+    def post(self, path: str, data: dict[str, str]) -> _Response:
+        return self.open(path, method="POST", data=data)
+
+
+class MiniApp:
+    def __init__(self, base_dir: Path):
+        self.base_dir = base_dir
+        self.styles = (base_dir / "static" / "styles.css").read_text(encoding="utf-8")
+
+    def test_client(self) -> _TestClient:
+        return _TestClient(self)
+
+    def __call__(self, environ, start_response) -> Iterable[bytes]:  # type: ignore[override]
+        path = environ.get("PATH_INFO", "/")
+        method = environ.get("REQUEST_METHOD", "GET").upper()
+
+        if path == "/static/styles.css":
+            body = self.styles.encode("utf-8")
+            start_response("200 OK", [("Content-Type", "text/css; charset=utf-8"), ("Content-Length", str(len(body)))])
+            return [body]
+
+        if path != "/":
+            body = b"Not Found"
+            start_response("404 Not Found", [("Content-Type", "text/plain"), ("Content-Length", str(len(body)))])
+            return [body]
+
+        ctx = CompileContext()
+        if method == "POST":
+            length = int(environ.get("CONTENT_LENGTH") or 0)
+            raw = environ.get("wsgi.input").read(length) if length else b""
+            form = parse_qs(raw.decode("utf-8"))
+            ctx.feature_text = form.get("feature_text", [""])[0]
+            ctx.scenario_name = form.get("scenario_name", [""])[0]
+            ctx.base_url = form.get("base_url", [""])[0]
+            ctx.use_llm = "use_llm" in form
+            ctx.llm_model = (form.get("llm_model", [ctx.llm_model])[0] or ctx.llm_model).strip() or ctx.llm_model
+
+            if not ctx.feature_text.strip():
+                ctx.error = "Feature text is required."
+            else:
+                compiler = Compiler(use_llm=ctx.use_llm, model=ctx.llm_model)
+                try:
+                    result = compiler.compile_text(
+                        feature_text=ctx.feature_text,
+                        scenario_name=ctx.scenario_name or None,
+                        base_url=ctx.base_url or None,
+                    )
+                    ctx.scenario_json = json.dumps(
+                        result.scenario.model_dump(exclude_none=True),
+                        indent=2,
+                    )
+                    ctx.provenance_json = json.dumps(
+                        [p.model_dump(exclude_none=True) for p in result.provenance],
+                        indent=2,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    ctx.error = str(exc)
+
+        body_str = _render_page(ctx)
+        body = body_str.encode("utf-8")
+        start_response("200 OK", [("Content-Type", "text/html; charset=utf-8"), ("Content-Length", str(len(body)))])
+        return [body]
+
+
+def _render_page(ctx: CompileContext) -> str:
+    feature_text = escape(ctx.feature_text)
+    scenario_name = escape(ctx.scenario_name)
+    base_url = escape(ctx.base_url)
+    llm_model = escape(ctx.llm_model)
+    checkbox_attr = " checked" if ctx.use_llm else ""
+
+    error_html = (
+        f'<div class="alert alert-error" role="alert"><strong>Compilation failed:</strong> {escape(ctx.error or "")}</div>'
+        if ctx.error
+        else ""
+    )
+
+    results_html = ""
+    if ctx.scenario_json:
+        results_html = (
+            "<div class=\"results\">"
+            "<h2>Scenario JSON</h2>"
+            f"<pre><code>{escape(ctx.scenario_json)}</code></pre>"
+            "<h2>Provenance</h2>"
+            f"<pre><code>{escape(ctx.provenance_json or '')}</code></pre>"
+            "</div>"
+        )
+
+    return f"""
+<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Automation Phase 1 — Web UI</title>
+  <link rel=\"stylesheet\" href=\"/static/styles.css\">
+</head>
+<body>
+  <header>
+    <h1>Automation Phase 1</h1>
+    <p>Compile Gherkin feature files to Playwright-ready scenarios without leaving your browser.</p>
+  </header>
+  <main>
+    <section class=\"card\">
+      <form method=\"post\" novalidate>
+        <div class=\"field\">
+          <label for=\"feature_text\">Gherkin feature</label>
+          <textarea id=\"feature_text\" name=\"feature_text\" rows=\"12\" placeholder=\"Paste your .feature content here...\">{feature_text}</textarea>
+        </div>
+        <div class=\"field-grid\">
+          <div class=\"field\">
+            <label for=\"scenario_name\">Scenario name</label>
+            <input id=\"scenario_name\" name=\"scenario_name\" type=\"text\" value=\"{scenario_name}\" placeholder=\"Defaults to first scenario\">
+          </div>
+          <div class=\"field\">
+            <label for=\"base_url\">Base URL override</label>
+            <input id=\"base_url\" name=\"base_url\" type=\"text\" value=\"{base_url}\" placeholder=\"https://example.com\">
+          </div>
+        </div>
+        <fieldset class=\"field-grid\">
+          <legend>Compiler options</legend>
+          <label class=\"checkbox\">
+            <input type=\"checkbox\" name=\"use_llm\"{checkbox_attr}>
+            Enable LLM fallback (requires API keys in environment)
+          </label>
+          <div class=\"field\">
+            <label for=\"llm_model\">LLM model</label>
+            <input id=\"llm_model\" name=\"llm_model\" type=\"text\" value=\"{llm_model}\">
+          </div>
+        </fieldset>
+        <button type=\"submit\" class=\"primary\">Compile feature</button>
+      </form>
+      {error_html}
+      {results_html}
+    </section>
+  </main>
+  <footer>
+    <p>Need the CLI? Run <code>python -m automation_phase1.cli --help</code>.</p>
+  </footer>
+</body>
+</html>
+"""
+
+
+def create_app() -> MiniApp:
+    base_dir = Path(__file__).resolve().parent
+    return MiniApp(base_dir)
+
+
+__all__ = ["create_app", "MiniApp"]

--- a/automation_phase1/webui/static/styles.css
+++ b/automation_phase1/webui/static/styles.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #eef2ff 0%, #f9fafb 100%);
+}
+
+header,
+footer {
+  padding: 1.5rem 2rem;
+  text-align: center;
+}
+
+header {
+  background-color: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.15);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 2.2vw, 2.5rem);
+}
+
+main {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.card {
+  width: min(960px, 100%);
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+textarea,
+input[type="text"] {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  background-color: #f8fafc;
+  color: inherit;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea:focus,
+input[type="text"]:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 500;
+}
+
+.checkbox input[type="checkbox"] {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+button.primary {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.35);
+}
+
+.alert {
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  font-weight: 500;
+}
+
+.alert-error {
+  background-color: #fee2e2;
+  color: #7f1d1d;
+  border: 1px solid #fecaca;
+}
+
+.results pre {
+  background-color: #0f172a;
+  color: #e0f2fe;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow: auto;
+  font-size: 0.95rem;
+}
+
+code {
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+footer {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+@media (max-width: 640px) {
+  header,
+  footer {
+    padding-inline: 1rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+}

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from automation_phase1.webui import create_app
+
+
+def test_index_get():
+    app = create_app()
+    client = app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"Automation Phase 1" in response.data
+    assert b"Gherkin feature" in response.data
+
+
+def test_compile_feature_shows_results():
+    app = create_app()
+    client = app.test_client()
+
+    feature = (
+        "Feature: Login\n"
+        "  Scenario: Happy path\n"
+        "    Given I open \"/login\"\n"
+        "    Then I should see text \"Welcome\"\n"
+    )
+
+    response = client.post(
+        "/",
+        data={
+            "feature_text": feature,
+            "scenario_name": "Happy path",
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"open_url" in response.data
+    assert b"get_text" in response.data


### PR DESCRIPTION
## Summary
- add a compiler entry point that accepts raw feature text to reuse in interactive tools
- build a minimal WSGI web UI with styling that compiles features and displays provenance alongside results
- document the browser-based workflow and cover the UI surface with unit tests

## Testing
- pytest *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c863e0ec83288973f16e1252b0c9